### PR TITLE
feat: pagination, media display, and clickable links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
+        "@tauri-apps/plugin-shell": "^2.3.5",
         "98.css": "^0.1.18"
       },
       "devDependencies": {
@@ -822,7 +823,6 @@
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1078,6 +1078,14 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-shell": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
+      "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
+      }
+    },
     "node_modules/@tsconfig/svelte": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
@@ -1106,7 +1114,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1352,7 +1359,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1471,7 +1477,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.2.tgz",
       "integrity": "sha512-yGONuIrcl/BMmqbm6/52Q/NYzfkta7uVlos5NSzGTfNJTTFtPPzra6rAQoQIwAqupeM3s9uuTf5PvioeiCdg9g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1538,7 +1543,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1552,7 +1556,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
+    "@tauri-apps/plugin-shell": "^2.3.5",
     "98.css": "^0.1.18"
   },
   "devDependencies": {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,7 @@ pub fn run() {
             commands::set_presence,
             commands::start_sync,
             commands::upload_file,
+            commands::fetch_media,
             commands::get_server_log,
             commands::accept_verification,
             commands::confirm_verification,

--- a/src-tauri/src/matrix_client.rs
+++ b/src-tauri/src/matrix_client.rs
@@ -30,6 +30,14 @@ pub struct Message {
     pub body: String,
     pub timestamp: u64,
     pub msg_type: String,
+    pub media_url: Option<String>,
+    pub filename: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessagesPage {
+    pub messages: Vec<Message>,
+    pub end_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/lib/linkify.ts
+++ b/src/lib/linkify.ts
@@ -1,0 +1,41 @@
+/** Escape HTML special characters to prevent XSS. */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
+/**
+ * Escape HTML then wrap URLs in clickable <a> tags.
+ * Handles trailing punctuation and Wikipedia-style parenthesised URLs.
+ */
+export function linkify(text: string): string {
+  const escaped = escapeHtml(text)
+  return escaped.replace(
+    /https?:\/\/[^\s<>&"']+/gi,
+    (match) => {
+      // Strip trailing punctuation that's unlikely part of the URL,
+      // but keep balanced parens (for Wikipedia-style URLs).
+      let url = match
+      let trailing = ''
+      const trailingPunct = /[.,;:!?)]+$/
+      while (trailingPunct.test(url)) {
+        const open = (url.match(/\(/g) || []).length
+        const close = (url.match(/\)/g) || []).length
+        if (url.endsWith(')') && open < close) {
+          trailing = url.slice(-1) + trailing
+          url = url.slice(0, -1)
+        } else if (url.endsWith(')')) {
+          break
+        } else {
+          trailing = url.slice(-1) + trailing
+          url = url.slice(0, -1)
+        }
+      }
+      return `<a href="${url}" target="_blank">${url}</a>${trailing}`
+    },
+  )
+}

--- a/src/lib/matrix.ts
+++ b/src/lib/matrix.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
-import type { Buddy, Room, Message, LoginCredentials, LogEntry, UserProfile, RoomProfile } from './types'
+import type { Buddy, Room, Message, MessagesPage, LoginCredentials, LogEntry, UserProfile, RoomProfile } from './types'
 
 export async function matrixLogin(credentials: LoginCredentials): Promise<string> {
   return invoke('matrix_login', { credentials })
@@ -29,8 +29,8 @@ export async function getRooms(): Promise<Room[]> {
   return invoke('get_rooms')
 }
 
-export async function getRoomMessages(roomId: string, limit: number = 50): Promise<Message[]> {
-  return invoke('get_room_messages', { roomId, limit })
+export async function getRoomMessages(roomId: string, limit: number = 50, from?: string): Promise<MessagesPage> {
+  return invoke('get_room_messages', { roomId, limit, from: from ?? null })
 }
 
 export async function sendMessage(roomId: string, body: string): Promise<void> {
@@ -91,4 +91,8 @@ export async function leaveRoom(roomId: string): Promise<void> {
 
 export async function removeBuddy(userId: string): Promise<void> {
   return invoke('remove_buddy', { userId })
+}
+
+export async function fetchMedia(mxcUrl: string): Promise<string> {
+  return invoke('fetch_media', { mxcUrl })
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,7 +30,14 @@ export interface Message {
   sender_name: string
   body: string
   timestamp: number
-  msg_type: 'text' | 'image' | 'file' | 'audio' | 'video'
+  msg_type: 'text' | 'image' | 'file' | 'audio' | 'video' | 'unknown'
+  media_url?: string | null
+  filename?: string | null
+}
+
+export interface MessagesPage {
+  messages: Message[]
+  end_token: string | null
 }
 
 export interface SharedRoom {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,16 @@
 import '98.css'
 import './app.css'
 import { mount } from 'svelte'
+import { open } from '@tauri-apps/plugin-shell'
+
+// Intercept clicks on <a target="_blank"> to open in system browser
+document.addEventListener('click', (e) => {
+  const anchor = (e.target as HTMLElement).closest('a[target="_blank"]') as HTMLAnchorElement | null
+  if (anchor?.href) {
+    e.preventDefault()
+    open(anchor.href)
+  }
+})
 
 const params = new URLSearchParams(window.location.search)
 const windowType = params.get('window')


### PR DESCRIPTION
## Summary

- **Pagination (#1):** Messages load in pages of 50. Scrolling to the top fetches older messages with scroll position preserved. A "new messages below" hint appears when new messages arrive while scrolled back, with a click-to-jump button.
- **Media display (#2):** Images render inline via authenticated media fetch (converted to base64 data URLs). Files, audio, and video show as download links that fetch through the authenticated API.
- **Clickable links (#9):** URLs in text messages are detected and wrapped in `<a>` tags with HTML escaping for XSS safety. Links open in the system browser via `@tauri-apps/plugin-shell`.

## Changes

**Rust backend:**
- `Message` struct gains `media_url` (mxc:// URL) and `filename` fields
- New `MessagesPage` struct with pagination `end_token`
- `get_room_messages` accepts `from` token for pagination, handles Image/File/Audio/Video message types
- New `fetch_media` command — authenticated media download with fallback, returns data URL
- Sync handler emits all media message types (not just text)

**Frontend:**
- `linkify.ts` — URL detection with `escapeHtml()` + `linkify()`, handles trailing punctuation and parens
- DM and ChatRoom components: scroll-based pagination, `loadMedia` Svelte action for authenticated image loading, `downloadFile` action for file downloads, "new messages below" hint bar
- `main.ts` — global click interceptor opens `<a target="_blank">` in system browser

## Test plan

- [ ] Open a room with 50+ messages, scroll to top — older messages load, scroll position preserved
- [ ] Receive a new message while scrolled up — "new messages below" hint appears, clicking it jumps down
- [ ] Send an image from Element — renders inline in ICQ26a
- [ ] Send a file — renders as clickable download link
- [ ] Send `https://example.com` in a message — blue clickable link, opens in system browser
- [ ] Send `<script>alert(1)</script>` — renders as escaped text (XSS safe)

Closes #1, closes #2, closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)